### PR TITLE
Added `snudda create` to create a project folder

### DIFF
--- a/snudda/cli.py
+++ b/snudda/cli.py
@@ -79,7 +79,10 @@ def create_project(args):
       print("Project creation aborted")
       return
     else:
+      # Delete the existing folder
       import shutil
       shutil.rmtree(args.path)
   from distutils.dir_util import copy_tree
+  # Copy the root data files folder to the specified path.
+  # The root data folder is the "snudda/data" folder, containing config, synapses & cellspecs.
   copy_tree(get_data_file(), args.path)


### PR DESCRIPTION
Having a command that creates dedicated project folders is a good way of seperating the source code from the data.

1. We package standard data that will be installed to an data directory that python controls
2. When we/users want to run simulations we create a project folder with `snudda create <my-project>` that will populate that folder with the standard config files, cellspecs etc.
3. The user can now mess with the config as much as they want, if they mess up they can just create a new project folder from the packaged data.

This also allows us to enforce 2 things:

* The Snudda CLI should always be run from a snudda project folder (that is a folder that contains a .snudda folder in it) or from another folder but by maybe specifying an optional `--project=<path>` they can link out to it.
* And by enforcing this we are always sure that the files are in the same location relative to the project path.

This will make it a lot easier to get rid of all the hardcoded file paths and to make our source files independent in location from the project files and to provide consistent behavior even when files or folders are moved around.