### PR TITLE
enabled non-uniform channel distribution

### DIFF
--- a/snudda/Neuron_model_extended.py
+++ b/snudda/Neuron_model_extended.py
@@ -149,7 +149,7 @@ class NeuronModel(ephys.models.CellModel):
       elif param_config['type'] in ['section', 'range']:
         if param_config['dist_type'] == 'uniform':
           scaler = ephys.parameterscalers.NrnSegmentLinearScaler()
-        elif param_config['dist_type'] == 'exp':
+        elif param_config['dist_type'] in ['exp', 'distance']:
           scaler = ephys.parameterscalers.NrnSegmentSomaDistanceScaler(
             distribution=param_config['dist'])
         seclist_loc = ephys.locations.NrnSeclistLocation(

--- a/snudda/data/cellspecs/dspn/str-dspn-e150602_c1_D1-mWT-0728MSN01-v20190508/parameters.json
+++ b/snudda/data/cellspecs/dspn/str-dspn-e150602_c1_D1-mWT-0728MSN01-v20190508/parameters.json
@@ -264,7 +264,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -274,7 +274,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -293,7 +293,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -348,7 +348,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -358,7 +358,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -650,7 +650,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -660,7 +660,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -679,7 +679,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -734,7 +734,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -744,7 +744,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1036,7 +1036,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1046,7 +1046,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1065,7 +1065,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1120,7 +1120,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1130,7 +1130,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1422,7 +1422,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1432,7 +1432,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1451,7 +1451,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1506,7 +1506,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1516,7 +1516,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1808,7 +1808,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1818,7 +1818,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1837,7 +1837,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1892,7 +1892,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1902,7 +1902,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -2194,7 +2194,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -2204,7 +2204,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -2223,7 +2223,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -2278,7 +2278,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -2288,7 +2288,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -2580,7 +2580,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -2590,7 +2590,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -2609,7 +2609,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -2664,7 +2664,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -2674,7 +2674,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -2966,7 +2966,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -2976,7 +2976,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -2995,7 +2995,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -3050,7 +3050,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -3060,7 +3060,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 

--- a/snudda/data/cellspecs/dspn/str-dspn-e150917_c10_D1-mWT-P270-20-v20190521/parameters.json
+++ b/snudda/data/cellspecs/dspn/str-dspn-e150917_c10_D1-mWT-P270-20-v20190521/parameters.json
@@ -264,7 +264,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -274,7 +274,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -293,7 +293,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -348,7 +348,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -358,7 +358,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -650,7 +650,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -660,7 +660,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -679,7 +679,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -734,7 +734,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -744,7 +744,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1036,7 +1036,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1046,7 +1046,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1065,7 +1065,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1120,7 +1120,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1130,7 +1130,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1422,7 +1422,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1432,7 +1432,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1451,7 +1451,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1506,7 +1506,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1516,7 +1516,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1808,7 +1808,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1818,7 +1818,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1837,7 +1837,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1892,7 +1892,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1902,7 +1902,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -2194,7 +2194,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -2204,7 +2204,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -2223,7 +2223,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -2278,7 +2278,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -2288,7 +2288,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 

--- a/snudda/data/cellspecs/dspn/str-dspn-e150917_c6_D1-m21-6-DE-v20190503/parameters.json
+++ b/snudda/data/cellspecs/dspn/str-dspn-e150917_c6_D1-m21-6-DE-v20190503/parameters.json
@@ -264,7 +264,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -274,7 +274,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -293,7 +293,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -348,7 +348,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -358,7 +358,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -650,7 +650,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -660,7 +660,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -679,7 +679,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -734,7 +734,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -744,7 +744,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1036,7 +1036,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1046,7 +1046,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1065,7 +1065,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1120,7 +1120,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1130,7 +1130,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1422,7 +1422,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1432,7 +1432,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1451,7 +1451,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1506,7 +1506,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1516,7 +1516,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1808,7 +1808,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1818,7 +1818,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1837,7 +1837,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1892,7 +1892,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1902,7 +1902,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -2194,7 +2194,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -2204,7 +2204,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -2223,7 +2223,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -2278,7 +2278,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -2288,7 +2288,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 

--- a/snudda/data/cellspecs/dspn/str-dspn-e150917_c9_d1-mWT-1215MSN03-v20190521/parameters.json
+++ b/snudda/data/cellspecs/dspn/str-dspn-e150917_c9_d1-mWT-1215MSN03-v20190521/parameters.json
@@ -264,7 +264,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -274,7 +274,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -293,7 +293,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -348,7 +348,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -358,7 +358,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -650,7 +650,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -660,7 +660,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -679,7 +679,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -734,7 +734,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -744,7 +744,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1036,7 +1036,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1046,7 +1046,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1065,7 +1065,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1120,7 +1120,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1130,7 +1130,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1422,7 +1422,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1432,7 +1432,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1451,7 +1451,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1506,7 +1506,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1516,7 +1516,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1808,7 +1808,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1818,7 +1818,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1837,7 +1837,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1892,7 +1892,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1902,7 +1902,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -2194,7 +2194,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -2204,7 +2204,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -2223,7 +2223,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -2278,7 +2278,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -2288,7 +2288,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -2580,7 +2580,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -2590,7 +2590,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -2609,7 +2609,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -2664,7 +2664,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -2674,7 +2674,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -2966,7 +2966,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -2976,7 +2976,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -2995,7 +2995,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -3050,7 +3050,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -3060,7 +3060,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -3352,7 +3352,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -3362,7 +3362,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -3381,7 +3381,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -3436,7 +3436,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -3446,7 +3446,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -3738,7 +3738,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -3748,7 +3748,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -3767,7 +3767,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -3822,7 +3822,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -3832,7 +3832,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 

--- a/snudda/data/cellspecs/ispn/str-ispn-e150908_c4_D2-m51-5-DE-v20190611/parameters.json
+++ b/snudda/data/cellspecs/ispn/str-ispn-e150908_c4_D2-m51-5-DE-v20190611/parameters.json
@@ -264,7 +264,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -274,7 +274,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -293,7 +293,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -348,7 +348,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -358,7 +358,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -650,7 +650,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -660,7 +660,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -679,7 +679,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -734,7 +734,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -744,7 +744,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1036,7 +1036,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1046,7 +1046,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1065,7 +1065,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1120,7 +1120,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1130,7 +1130,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1422,7 +1422,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1432,7 +1432,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1451,7 +1451,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1506,7 +1506,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1516,7 +1516,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1808,7 +1808,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1818,7 +1818,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1837,7 +1837,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1892,7 +1892,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1902,7 +1902,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -2194,7 +2194,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -2204,7 +2204,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -2223,7 +2223,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -2278,7 +2278,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -2288,7 +2288,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -2580,7 +2580,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -2590,7 +2590,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -2609,7 +2609,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -2664,7 +2664,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -2674,7 +2674,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 

--- a/snudda/data/cellspecs/ispn/str-ispn-e150917_c11_D2-mWT-MSN1-v20190603/parameters.json
+++ b/snudda/data/cellspecs/ispn/str-ispn-e150917_c11_D2-mWT-MSN1-v20190603/parameters.json
@@ -264,7 +264,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -274,7 +274,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -293,7 +293,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -348,7 +348,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -358,7 +358,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -650,7 +650,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -660,7 +660,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -679,7 +679,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -734,7 +734,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -744,7 +744,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1036,7 +1036,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1046,7 +1046,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1065,7 +1065,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1120,7 +1120,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1130,7 +1130,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1422,7 +1422,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1432,7 +1432,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1451,7 +1451,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1506,7 +1506,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1516,7 +1516,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1808,7 +1808,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1818,7 +1818,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1837,7 +1837,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1892,7 +1892,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1902,7 +1902,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -2194,7 +2194,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -2204,7 +2204,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -2223,7 +2223,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -2278,7 +2278,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -2288,7 +2288,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 

--- a/snudda/data/cellspecs/ispn/str-ispn-e151123_c1_D2-mWT-P270-09-v20190527/parameters.json
+++ b/snudda/data/cellspecs/ispn/str-ispn-e151123_c1_D2-mWT-P270-09-v20190527/parameters.json
@@ -264,7 +264,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -274,7 +274,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -293,7 +293,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -348,7 +348,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -358,7 +358,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -650,7 +650,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -660,7 +660,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -679,7 +679,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -734,7 +734,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -744,7 +744,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1036,7 +1036,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1046,7 +1046,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1065,7 +1065,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1120,7 +1120,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1130,7 +1130,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1422,7 +1422,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1432,7 +1432,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1451,7 +1451,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1506,7 +1506,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1516,7 +1516,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1808,7 +1808,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1818,7 +1818,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1837,7 +1837,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1892,7 +1892,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1902,7 +1902,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 

--- a/snudda/data/cellspecs/ispn/str-ispn-e160118_c10_D2-m46-3-DE-v20190529/parameters.json
+++ b/snudda/data/cellspecs/ispn/str-ispn-e160118_c10_D2-m46-3-DE-v20190529/parameters.json
@@ -264,7 +264,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -274,7 +274,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -293,7 +293,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -348,7 +348,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -358,7 +358,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -650,7 +650,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -660,7 +660,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -679,7 +679,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -734,7 +734,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -744,7 +744,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 
@@ -1036,7 +1036,7 @@
     }, 
     {
         "dist": "((0.1) + (0.9)/(1 + exp(({distance}-(40))/(10))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "naf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_naf_ms", 
@@ -1046,7 +1046,7 @@
     }, 
     {
         "dist": "((1.0) + (0.5)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kaf_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kaf_ms", 
@@ -1065,7 +1065,7 @@
     }, 
     {
         "dist": "((1.0) + (9.0)*exp(({distance}-(0.0))/(-5.0)))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "kas_ms", 
         "mech_param": "gbar", 
         "param_name": "gbar_kas_ms", 
@@ -1120,7 +1120,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat32_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat32_ms", 
@@ -1130,7 +1130,7 @@
     }, 
     {
         "dist": "((0.0) + (1.0)/(1 + exp(({distance}-(120))/(-30))))*{value}", 
-        "dist_type": "distance", 
+        "dist_type": "uniform", 
         "mech": "cat33_ms", 
         "mech_param": "pbar", 
         "param_name": "pbar_cat33_ms", 


### PR DESCRIPTION
fix in Neuron_model_extended.py line 152
dist_type == "exp" -> in ["exp","distance"].
Also "fixed" parameter files of spns to use uniform distribution