### PR TITLE
Simulate parallel synchronisation issue

### DIFF
--- a/snudda/simulate/simulate.py
+++ b/snudda/simulate/simulate.py
@@ -114,6 +114,8 @@ class SnuddaSimulate(object):
         self.fih_time = None
         self.last_sim_report_time = 0
 
+        self.pc = h.ParallelContext()
+
         if simulation_config:
             sim_info = json.load(simulation_config)
 
@@ -127,6 +129,7 @@ class SnuddaSimulate(object):
                 self.log_file = open(sim_info["logFile"], "w")
 
         if type(self.log_file) == str:
+            self.log_file += f'-{int(self.pc.id())}'
             self.log_file = open(self.log_file, "w")
 
         self.write_log(f"Using networkFile: {self.network_file}")
@@ -176,7 +179,6 @@ class SnuddaSimulate(object):
         # cant write file
         self.create_dir(os.path.join("save", "traces"))
 
-        self.pc = h.ParallelContext()
 
         self.conv_factor = {"tauR": 1e3,
                             "tauF": 1e3,

--- a/snudda/simulate/simulate.py
+++ b/snudda/simulate/simulate.py
@@ -852,10 +852,10 @@ class SnuddaSimulate(object):
                         val_orig = val
                         val = self.convert_to_natural_units(par, val)
 			
-		    if par in ["tau", "tauR"]:
-			if (0.01 > val) or (val >= 10000):
-			    self.write_log("Warning: {} was converted from {} to {} "
-					   "but expected range [0.01, 10000).")
+                    if par in ["tau", "tauR"] and ((0.01 > val) or (val >= 10000)):
+                        self.write_log(" !!! Warning: Converted from {} to {} but expected "\
+                                        "a value within [0.01, 10000) for neuron id {}. "\
+                                            .format(val_orig, val, cell_id_source))
                     setattr(syn, par, val)
 
                 except:

--- a/snudda/simulate/simulate.py
+++ b/snudda/simulate/simulate.py
@@ -196,6 +196,8 @@ class SnuddaSimulate(object):
 
         self.check_memory_status()
         self.distribute_neurons()
+        self.pc.barrier()
+
         self.setup_neurons()
         self.check_memory_status()
         self.pc.barrier()

--- a/snudda/simulate/simulate.py
+++ b/snudda/simulate/simulate.py
@@ -844,12 +844,6 @@ class SnuddaSimulate(object):
                         val_orig = val
                         val = self.convert_to_natural_units(par, val)
 
-                    # Temp sanity check for synapse time constant
-                    if par in ["tau", "tauR"]:
-                        assert 0.01 <= val < 10000, \
-                            (f"Cell {self.neurons[cell_id_source].name} converting {par}={val_orig} to {val}, "
-                             f"expected >= 0.01 and < 10000.")
-
                     setattr(syn, par, val)
 
                 except:

--- a/snudda/simulate/simulate.py
+++ b/snudda/simulate/simulate.py
@@ -843,7 +843,11 @@ class SnuddaSimulate(object):
                         # If no list, we need to handle SI to natural units conversion automatically
                         val_orig = val
                         val = self.convert_to_natural_units(par, val)
-
+			
+		    if par in ["tau", "tauR"]:
+			if (0.01 > val) or (val >= 10000):
+			    self.write_log("Warning: {} was converted from {} to {} "
+					   "but expected range [0.01, 10000).")
                     setattr(syn, par, val)
 
                 except:


### PR DESCRIPTION
Since the parameter bug fix, I have not been able to run any parallel simulations (out of a lot of attempts) on Beskow even though it is running fine in serial. It also seems to crash at random points and in different functions during setup. 

I added barrier blocks between the main steps during setup as attached here and now it runs ok again. 

(I also changed the parameter sanity check to a warning message and changed the logging to output separate log files for each node.)