### PR TITLE
To keep 'snudda_data' as optional parameter in snudda_parse_path()

### DIFF
--- a/snudda/utils/snudda_path.py
+++ b/snudda/utils/snudda_path.py
@@ -10,7 +10,7 @@ import numpy as np
 # TODO: Add SNUDDA_PATH to network_config file
 
 
-def snudda_parse_path(path, snudda_data):
+def snudda_parse_path(path, snudda_data=None):
     """ Parses a data path, replacing $DATA with the path to SNUDDA_DATA set by environment variable.
 
     Args:


### PR DESCRIPTION
Description states:
>snudda_data (str) : Path to SNUDDA_DATA, this is optional, and if given overrides environment variable