### PR TITLE
Update bend_morphologies.py

### DIFF
--- a/snudda/place/bend_morphologies.py
+++ b/snudda/place/bend_morphologies.py
@@ -57,9 +57,9 @@ class BendMorphologies:
                 parent_dir, parent_point, parent_dist, parent_moved = parent_direction[section.section_id, section.section_type]
             else:
                 if morphology.rotation is not None:
-                    parent_dir = np.matmul(morphology.rotation, np.array([[1], [0], [0]])).T
+                    parent_dir = np.matmul(morphology.rotation, np.array([[0], [0], [1]])).T
                 else:
-                    parent_dir = np.array([[1, 0, 0]])
+                    parent_dir = np.array([[0, 0, 1]])
 
                 if morphology.position is not None:
                     parent_point = morphology.position
@@ -145,7 +145,7 @@ class BendMorphologies:
             if (section.section_id, section.section_type) in parent_direction.keys():
                 parent_dir = parent_direction[section.section_id, section.section_type]
             else:
-                parent_dir = np.array([[1, 0, 0]])
+                parent_dir = np.array([[0, 0, 1]])
 
             try:
                 rot_and_len, last_direction = self.rotation_representation(section=section, parent_direction=parent_dir)
@@ -174,9 +174,9 @@ class BendMorphologies:
                 parent_dir, parent_pos = parent_direction[section.section_id, section.section_type]
             else:
                 if morphology.rotation is not None:
-                    parent_dir = np.matmul(morphology.rotation, np.array([[1, 0, 0]]).T).T
+                    parent_dir = np.matmul(morphology.rotation, np.array([[0, 0, 1]]).T).T
                 else:
-                    parent_dir = np.array([[1, 0, 0]])
+                    parent_dir = np.array([[0, 0, 1]])
 
                 if morphology.position is not None:
                     parent_pos = morphology.position
@@ -223,7 +223,7 @@ class BendMorphologies:
 
         if parent_direction is None:
             # parent_direction = np.array([[1, 0, 0]])
-            parent_direction = np.array([1, 0, 0])
+            parent_direction = np.array([0, 0, 1])
 
         rotations_and_length = []
         parent_direction = parent_direction / np.linalg.norm(parent_direction)


### PR DESCRIPTION
rotation from vector field uses [0,0,1] as the morphology direction that is to be aligned with the vector field. This convention needs to match here, or bent morphologies are not rotated properly with the vector field.