### PR TITLE
Update neuron_morphology_extended.py

### DIFF
--- a/snudda/neurons/neuron_morphology_extended.py
+++ b/snudda/neurons/neuron_morphology_extended.py
@@ -461,7 +461,14 @@ class NeuronMorphologyExtended:
                 comp_x = rng.random(num_locations)
                 xyz = comp_x[:, None] * geometry[syn_idx, :3] + (1-comp_x[:, None]) * geometry[parent_idx[syn_idx], :3]
                 sec_id = section_data[syn_idx, 0]
-                sec_x = comp_x * section_data[syn_idx, 1] + (1-comp_x) * section_data[parent_idx[syn_idx], 1]
+
+                ##dont interpolate sec_x from parent if new branch or if parent is soma
+                #sec_x = comp_x * section_data[syn_idx, 1] + (1-comp_x) * section_data[parent_idx[syn_idx], 1]
+                same_section = np.all(section_data[syn_idx][:, [0, 2]] == section_data[parent_idx[syn_idx]][:, [0, 2]], axis=1)
+                sec_x = np.where(same_section,
+                                  comp_x * section_data[syn_idx, 1] + (1-comp_x) * section_data[parent_idx[syn_idx], 1],
+                                  comp_x * section_data[syn_idx, 1])    
+                
                 dist_to_soma = comp_x * geometry[syn_idx, 4] + (1-comp_x) * geometry[parent_idx[syn_idx], 4]
             except:
                 import traceback
@@ -491,7 +498,10 @@ class NeuronMorphologyExtended:
             comp_x = rng.random(num_pos)
             xyz = comp_x[:, None] * geometry[cluster_syn_idx, :3] + (1 - comp_x[:, None]) * geometry[parent_idx[cluster_syn_idx], :3]
             sec_id = section_data[cluster_syn_idx, 0]
-            sec_x = comp_x * section_data[cluster_syn_idx, 1] + (1 - comp_x) * section_data[parent_idx[cluster_syn_idx], 1]
+            ##dont interpolate sec_x from parent if new branch or if parent is soma
+            #sec_x = comp_x * section_data[cluster_syn_idx, 1] + (1 - comp_x) * section_data[parent_idx[cluster_syn_idx], 1]
+            same_section = np.all(section_data[syn_idx][:, [0, 2]] == section_data[parent_idx[syn_idx]][:, [0, 2]], axis=1)
+            sec_x = np.where(same_section, comp_x * section_data[syn_idx, 1] + (1-comp_x) * section_data[parent_idx[syn_idx], 1], comp_x * section_data[syn_idx, 1])    
             dist_to_soma = comp_x * geometry[cluster_syn_idx, 4] + (1 - comp_x) * geometry[parent_idx[cluster_syn_idx], 4]
 
         return xyz, sec_id, sec_x / 1e3, dist_to_soma

--- a/snudda/neurons/neuron_morphology_extended.py
+++ b/snudda/neurons/neuron_morphology_extended.py
@@ -500,8 +500,8 @@ class NeuronMorphologyExtended:
             sec_id = section_data[cluster_syn_idx, 0]
             ##dont interpolate sec_x from parent if new branch or if parent is soma
             #sec_x = comp_x * section_data[cluster_syn_idx, 1] + (1 - comp_x) * section_data[parent_idx[cluster_syn_idx], 1]
-            same_section = np.all(section_data[syn_idx][:, [0, 2]] == section_data[parent_idx[syn_idx]][:, [0, 2]], axis=1)
-            sec_x = np.where(same_section, comp_x * section_data[syn_idx, 1] + (1-comp_x) * section_data[parent_idx[syn_idx], 1], comp_x * section_data[syn_idx, 1])    
+            same_section = np.all(section_data[cluster_syn_idx][:, [0, 2]] == section_data[parent_idx[cluster_syn_idx]][:, [0, 2]], axis=1)
+            sec_x = np.where(same_section, comp_x * section_data[cluster_syn_idx, 1] + (1-comp_x) * section_data[parent_idx[cluster_syn_idx], 1], comp_x * section_data[cluster_syn_idx, 1])    
             dist_to_soma = comp_x * geometry[cluster_syn_idx, 4] + (1 - comp_x) * geometry[parent_idx[cluster_syn_idx], 4]
 
         return xyz, sec_id, sec_x / 1e3, dist_to_soma


### PR DESCRIPTION
sec_x should not be interpolated between idx and parent_idx if parent is soma or branch point. Otherwise sec_x is wildly off, and ultimate synapse placing doesn't reflect xyz coordinates, or dendritic density. Affects ~5% of synapses if placement density is perisomatic. Up until now synapse placement is only verified for synapses between simulated neurons and not extrinsic input, so I think this has been overlooked for some time. 