### PR TITLE
Add reset_random123 option to clear_neuron()

### DIFF
--- a/snudda/simulate/simulate.py
+++ b/snudda/simulate/simulate.py
@@ -3232,7 +3232,7 @@ class SnuddaSimulate(object):
             except:
                 pass
 
-    def clear_neuron(self):
+    def clear_neuron(self, reset_random123=False):
 
         if self.pc is not None:
             self.pc.gid_clear()
@@ -3264,6 +3264,16 @@ class SnuddaSimulate(object):
         if h is not None:
             for sec in list(h.allsec()):  # Convert to list to avoid modifying during iteration
                 h.delete_section(sec=sec)
+            if reset_random123:
+                h.nrnran123_setglobalindex(0)
+            else:
+                import warnings
+                warnings.warn(
+                    "clear_neuron() called with reset_random123=False. "
+                    "If you plan to run another simulation in the same process, "
+                    "set reset_random123=True to ensure reproducible Random123 streams.",
+                    UserWarning, stacklevel=2
+                )
 
         self.sim = None
 


### PR DESCRIPTION
When running multiple SnuddaSimulate instances sequentially in the same Python process, NEURON's Random123 global index keeps incrementing across runs so RANDOM streams in the second run get different internal ids than the first, causing non-reproducible results even with identical inputs.

clear_neuron(reset_random123=True) now calls h.nrnran123_setglobalindex(0) after deleting all sections, so the next simulation's RANDOM objects are assigned the same ids as the previous run.  Default is False to preserve existing behaviour; a UserWarning is emitted when False to alert users who intend to run a follow-up simulation in the same process.