### PR TITLE
Fix three bugs in SwapToDegeneratedMorphologies; add regression test

### DIFF
--- a/snudda/utils/swap_to_degenerated_morphologies.py
+++ b/snudda/utils/swap_to_degenerated_morphologies.py
@@ -63,6 +63,7 @@ class SwapToDegeneratedMorphologies:
         self.filter_axon = filter_axon
         self.old_simulation_origo = self.old_hdf5["meta/simulation_origo"][()]
         self.old_voxel_size = self.old_hdf5["meta/voxel_size"][()]
+        self.rng = np.random.default_rng()
 
         self.has_axon_density = np.zeros((self.original_network_loader.data["num_neurons"],), dtype=bool)
         for neuron_id, _ in enumerate(self.original_network_loader.data["neurons"]):
@@ -195,9 +196,11 @@ class SwapToDegeneratedMorphologies:
         self.new_hdf5["network"].create_dataset("num_synapses", data=syn_ctr, dtype=np.uint64)
 
         try:
-            print(f"Keeping {self.new_hdf5['network/num_synapses'][()]} "
-                  f"out of {self.old_hdf5['network/num_synapses'][()][0]} synapses "
-                  f"({self.new_hdf5['network/num_synapses'][()] / max(1,self.old_hdf5['network/num_synapses'][()][0])*100:.3f} %)")
+            old_n = self.old_hdf5['network/num_synapses'][()]
+            if hasattr(old_n, '__len__'):
+                old_n = old_n[0]
+            new_n = self.new_hdf5['network/num_synapses'][()]
+            print(f"Keeping {new_n} out of {old_n} synapses ({new_n / max(1, old_n) * 100:.3f} %)")
         except:
             import traceback
             print(traceback.format_exc())
@@ -221,12 +224,11 @@ class SwapToDegeneratedMorphologies:
         self.new_hdf5["network"].create_dataset("num_gap_junctions", data=gj_ctr, dtype=np.uint64)
 
         try:
-            n_gj = self.old_hdf5['network/num_gap_junctions'][()][0] \
-                if hasattr(self.old_hdf5['network/num_gap_junctions'][()], "__len__") \
-                else self.old_hdf5['network/num_gap_junctions'][()]
-            print(f"Keeping {n_gj} "
-                  f"out of {[0]} gap junctions "
-                  f"({n_gj / max(1, n_gj)*100:.3f} %)")
+            old_n_gj = self.old_hdf5['network/num_gap_junctions'][()]
+            if hasattr(old_n_gj, '__len__'):
+                old_n_gj = old_n_gj[0]
+            print(f"Keeping {gj_ctr} out of {old_n_gj} gap junctions "
+                  f"({gj_ctr / max(1, old_n_gj) * 100:.3f} %)")
         except:
             import traceback
             print(traceback.format_exc())

--- a/tests/test_degeneration.py
+++ b/tests/test_degeneration.py
@@ -1,3 +1,5 @@
+import io
+import contextlib
 import os
 import numpy as np
 import h5py
@@ -6,6 +8,7 @@ import unittest
 
 from snudda import SnuddaDetect, SnuddaPrune
 from snudda.plotting import PlotNetwork
+from snudda.utils.swap_to_degenerated_morphologies import SwapToDegeneratedMorphologies
 from snudda.utils.swap_to_degenerated_morphologies_extended import SwapToDegeneratedMorphologiesExtended
 
 
@@ -144,6 +147,55 @@ class MyTestCase(unittest.TestCase):
                 hdf5_file["network/neurons/rotation"][20, :] = R_gj.flatten()
 
             hdf5_file.close()
+
+    def test_base_swap_morphologies(self):
+        """Regression test for three bugs in SwapToDegeneratedMorphologies:
+        1. self.rng not initialised in __init__ (AttributeError on write_new_input_file)
+        2. num_synapses scalar indexing crash in write_new_network_file print statement
+        3. gap junction print showing wrong retained count and literal '[0]'
+        """
+        network_D = os.path.join("networks", "network_testing_degeneration", "D")
+        os.makedirs(network_D, exist_ok=True)
+        network_A_file = os.path.join(self.network_A, "network-synapses.hdf5")
+        network_D_file = os.path.join(network_D, "network-synapses.hdf5")
+
+        original_data_dir = os.path.join("validation", "ballanddoublestick_original")
+        updated_data_dir = os.path.join("validation", "ballanddoublestick_degenerated")
+
+        swap = SwapToDegeneratedMorphologies(
+            original_network_file=network_A_file,
+            new_network_file=network_D_file,
+            original_snudda_data_dir=original_data_dir,
+            new_snudda_data_dir=updated_data_dir,
+            filter_axon=True,
+        )
+
+        # Bug 1: self.rng must be initialised after __init__
+        self.assertTrue(hasattr(swap, "rng"),
+                        "self.rng not initialised in __init__")
+
+        # Bugs 2 & 3: write_new_network_file must not produce a traceback in its
+        # summary print statements (previously swallowed by bare except)
+        stdout_buf = io.StringIO()
+        with contextlib.redirect_stdout(stdout_buf):
+            swap.write_new_network_file()
+        output = stdout_buf.getvalue()
+
+        self.assertNotIn("Traceback", output,
+                         "write_new_network_file() printed a traceback — "
+                         "num_synapses or gap-junction print statement is broken")
+
+        # Verify the synapse summary line was printed with correct format
+        self.assertIn("synapses", output,
+                      "Expected synapse summary line missing from output")
+
+        # Verify gap junction summary line was printed (bug 3: used to print 'out of [0]')
+        self.assertIn("gap junctions", output,
+                      "Expected gap junction summary line missing from output")
+        self.assertNotIn("out of [0]", output,
+                         "Gap junction print still contains literal '[0]'")
+
+        swap.close()
 
     def test_something(self):
 


### PR DESCRIPTION
Not hundred percent sure about this - but claude insists - so better check it...

Fix three bugs in SwapToDegeneratedMorphologies
    
    Bugs fixed:
    - self.rng missing from __init__: raised AttributeError when
      write_new_input_file() was called with remap_removed_input=True
    - num_synapses print: unconditional [0] indexing crashed on scalar HDF5
      datasets (written by SnuddaPrune as plain scalars); now guards with
      hasattr(..., '__len__')
    - gap junction print: printed literal '[0]' for 'out of N' count, and
      reported n_gj (old count) as the retained count instead of gj_ctr;
      both corrected
    
    Regression test added to test_degeneration.py:
    - Verifies self.rng exists after __init__
    - Captures stdout from write_new_network_file() and asserts no Traceback
      appears and that the synapse/gap-junction summary lines are well-formed

