### PR TITLE
Add upper conductance cap to regular synapses and gap junctions

### DIFF
--- a/snudda/detect/detect.py
+++ b/snudda/detect/detect.py
@@ -1344,8 +1344,8 @@ class SnuddaDetect(object):
                                 cond = self.hyper_voxel_rng.lognormal(synapse_mu, synapse_sigma)
 
                                 # Need to make sure the conductance is not negative,
-                                # set lower cap at 10% of mean value
-                                cond = np.maximum(cond, mean_synapse_cond * 0.1)
+                                # set lower cap at 10% and upper cap at 10x mean value
+                                cond = np.minimum(np.maximum(cond, mean_synapse_cond * 0.1), mean_synapse_cond * 10)
                                 assert cond > 0, f"Conductance should be larger than 0. cond = {cond}"
 
                                 param_id = self.hyper_voxel_rng.integers(1000000)
@@ -1939,7 +1939,7 @@ class SnuddaDetect(object):
                         # lognormal distribution https://www.nature.com/articles/nrn3687
                         gj_cond = self.hyper_voxel_rng.lognormal(gj_mu, gj_sigma)
 
-                        gj_cond = np.maximum(gj_cond, mean_gj_cond * 0.1)  # Avoid negative cond
+                        gj_cond = np.minimum(np.maximum(gj_cond, mean_gj_cond * 0.1), mean_gj_cond * 10)  # Clamp to [10%, 10x] of mean
 
                         self.hyper_voxel_gap_junctions[self.hyper_voxel_gap_junction_ctr, :] = \
                             [neuron_id1, neuron_id2, seg_id1, seg_id2, seg_x1 * 1e3, seg_x2 * 1e3,


### PR DESCRIPTION
Apply the same [10%, 10x] mean clamp to regular (non-clustered) internal synapses and gap junctions that was already in place for clustered synapses, making conductance bounding consistent across all connection types.